### PR TITLE
Fix select option background color in dark mode

### DIFF
--- a/forms.html
+++ b/forms.html
@@ -495,11 +495,11 @@
                             <div class="mb-2">
                                 <label for="select-example" class="mb-1 text-sm font-semibold">Select</label>
                             </div>
-                            <select name="select_example" id="select-example" class="w-full h-10 px-2 mb-1 text-sm bg-transparent border border-gray-400 rounded appearance-none disabled:bg-gray-100 dark:disabled:bg-gray-700 focus:border-blue-500 dark:border-gray-600 focus:ring-blue-500 focus:outline-none">
-                                <option class="dark:bg-gray-800" value="" selected>Select example</option>
-                                <option class="dark:bg-gray-800" value="Option 1">Option 1</option>
-                                <option class="dark:bg-gray-800" value="Option 2">Option 2</option>
-                                <option class="dark:bg-gray-800" value="Option 3">Option 3</option>
+                            <select name="select_example" id="select-example" class="w-full h-10 px-2 mb-1 text-sm bg-transparent border border-gray-400 rounded appearance-none disabled:bg-gray-100 dark:disabled:bg-gray-700 focus:border-blue-500 dark:border-gray-600 focus:ring-blue-500 focus:outline-none dark:bg-gray-800">
+                                <option value="" selected>Select example</option>
+                                <option value="Option 1">Option 1</option>
+                                <option value="Option 2">Option 2</option>
+                                <option value="Option 3">Option 3</option>
                             </select>
                         </div>
 

--- a/forms.html
+++ b/forms.html
@@ -496,10 +496,10 @@
                                 <label for="select-example" class="mb-1 text-sm font-semibold">Select</label>
                             </div>
                             <select name="select_example" id="select-example" class="w-full h-10 px-2 mb-1 text-sm bg-transparent border border-gray-400 rounded appearance-none disabled:bg-gray-100 dark:disabled:bg-gray-700 focus:border-blue-500 dark:border-gray-600 focus:ring-blue-500 focus:outline-none">
-                                <option value="" selected>Select example</option>
-                                <option value="Option 1">Option 1</option>
-                                <option value="Option 2">Option 2</option>
-                                <option value="Option 3">Option 3</option>
+                                <option class="dark:bg-gray-800" value="" selected>Select example</option>
+                                <option class="dark:bg-gray-800" value="Option 1">Option 1</option>
+                                <option class="dark:bg-gray-800" value="Option 2">Option 2</option>
+                                <option class="dark:bg-gray-800" value="Option 3">Option 3</option>
                             </select>
                         </div>
 


### PR DESCRIPTION
Just found out that the options can't be read in the dark mode. It's not a major problem anyway, but it is pretty annoying because we need to hover on the option every time to see them.


![Screenshot 2022-09-05 140909](https://user-images.githubusercontent.com/34534953/188372904-3078f6ab-f496-48cc-81bc-5bb95dd54163.png)

I think this is what it should look like.

![Screenshot 2022-09-05 141043](https://user-images.githubusercontent.com/34534953/188372926-749ed0ac-85ce-4a3d-89f3-6e974e3dcddd.png)
